### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 0.1.0
+- Fixed connection for other Clojure implementations like Clojerl, Joker, etc.
+- Interactive results
+- First support for `info` command, if "Orchard" is on classpath
+- Code refactoring, fixed issues
+- Loading tests on full refresh
+- Fixed parsing of namespaces with metadata, and quotes (the kind you get when using clj-kondo)
+- Load-file now prints the stacktrace when it fails to load
+- Fixed paths on Windows, so goto var definition and clicking on stacktraces will work
+- Simple fix for nREPL on slower sockets
+- Alpha support for nREPL
+- Fixed connection with Babashka
+- Fixed issue with GOTO Var Definition when the current file's full path is too long.
+
+
 ## 0.0.7
 - Support for nREPL
 - Indentation engine (alpha)

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,12 +35,6 @@
 				"util": "0.10.3"
 			},
 			"dependencies": {
-				"inherits": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
-				},
 				"util": {
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -350,13 +344,33 @@
 			}
 		},
 		"hash-base": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"hash.js": {
@@ -367,6 +381,14 @@
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				}
 			}
 		},
 		"hmac-drbg": {
@@ -401,9 +423,9 @@
 			"dev": true
 		},
 		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+			"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
 			"dev": true
 		},
 		"is-stream": {
@@ -478,21 +500,6 @@
 			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
 			"dev": true
 		},
-		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
-		},
-		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
-			"requires": {
-				"minimist": "0.0.8"
-			}
-		},
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -531,14 +538,6 @@
 				"url": "^0.11.0",
 				"util": "^0.11.0",
 				"vm-browserify": "^1.0.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
 			}
 		},
 		"object-assign": {
@@ -635,6 +634,12 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -667,9 +672,9 @@
 			}
 		},
 		"react": {
-			"version": "16.9.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-			"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -677,20 +682,20 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.9.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-			"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.15.0"
+				"scheduler": "^0.19.1"
 			}
 		},
 		"react-is": {
-			"version": "16.9.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-			"integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",
@@ -707,6 +712,12 @@
 				"util-deprecate": "~1.0.1"
 			},
 			"dependencies": {
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				},
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -752,9 +763,9 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"scheduler": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-			"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -776,24 +787,23 @@
 			}
 		},
 		"shadow-cljs": {
-			"version": "2.8.83",
-			"resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.8.83.tgz",
-			"integrity": "sha512-oqqSLARvYXopA9QLf5znrguvJOSRm65LYL9XHuRWaUbMGXlygqgCjSFgW1yREXmqUQ+i2TLoA1zulYO6nTTy6g==",
+			"version": "2.8.109",
+			"resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.8.109.tgz",
+			"integrity": "sha512-xUN5kBYgyk2OVv3Gz9/dxJdDNoImskYg6VNLpHkubCG46Q1Lv9tymd11Hyekka6WWk24QCNSVIyPta82txZGfQ==",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1",
 				"node-libs-browser": "^2.0.0",
 				"readline-sync": "^1.4.7",
-				"shadow-cljs-jar": "1.3.1",
+				"shadow-cljs-jar": "1.3.2",
 				"source-map-support": "^0.4.15",
 				"which": "^1.3.1",
 				"ws": "^3.0.0"
 			}
 		},
 		"shadow-cljs-jar": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.1.tgz",
-			"integrity": "sha512-IJSm4Gfu/wWDsOQ0wNrSxuaGdjzsd78us+3bop3cpWsoO2Igdu6VIBItYrZHRRBKl5LIZKXfnSh/2eWG3C1EFw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz",
+			"integrity": "sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==",
 			"dev": true
 		},
 		"source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "clover",
-	"version": "0.0.7",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Socket REPL development for your editor",
 	"publisher": "mauricioszabo",
 	"repository": "https://github.com/mauricioszabo/clover/",
-	"version": "0.0.7",
+	"version": "0.1.0",
 	"engines": {
 		"vscode": "^1.38.0"
 	},

--- a/package.json
+++ b/package.json
@@ -114,13 +114,13 @@
 		}
 	},
 	"devDependencies": {
-		"shadow-cljs": "^2.8.83"
+		"shadow-cljs": "^2.8.109"
 	},
 	"dependencies": {
 		"ansi_up": "^4.0.4",
 		"create-react-class": "^15.6.3",
-		"react": "^16.9.0",
-		"react-dom": "^16.9.0"
+		"react": "^16.13.1",
+		"react-dom": "^16.13.1"
 	},
 	"__metadata": {
 		"id": "46228898-6f2d-4345-b0a1-110cecdc9866",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,8 +1,9 @@
 ;; shadow-cljs configuration
 {:source-paths ["src" "repl-tooling/src" "repl-tooling/resources"]
 
- :dependencies [[repl-tooling "0.4.3"]
+ :dependencies [[repl-tooling "0.4.4-SNAPSHOT"]
                 [org.rksm/suitable "0.3.2"]
+                [compliment "0.4.0-SNAPSHOT"]
                 [cljfmt "0.6.7"]]
 
  :builds {:plugin {:target :node-library

--- a/src/clover/commands/connection.cljs
+++ b/src/clover/commands/connection.cljs
@@ -57,8 +57,7 @@
         :on-eval #(ui/send-result! % :clj)
         ; :on-start-eval vs/info
         ; :on-eval vs/info
-        :on-patch #(ui/post-message! {:command :patch
-                                      :obj %})
+        :on-patch #(ui/post-message! {:command :patch :obj %})
         :editor-data vs/get-editor-data
         :notify notify!})
       (then #(when-let [st %]

--- a/src/clover/ui.cljs
+++ b/src/clover/ui.cljs
@@ -190,7 +190,6 @@ span.icon {
 </html>"))))
 
 (defn post-message! [message]
-  (prn :MESSAGE message)
   (.. ^js @view -webview
       (postMessage (pr-str message))))
 

--- a/src/clover/ui.cljs
+++ b/src/clover/ui.cljs
@@ -23,7 +23,7 @@
   src: url(" res-font-path ");
 }
 
-div.chlorine.console {
+div.repl-tooling.console {
   width: 100%;
   height: 100%;
   color: var(--vscode-editor-foreground);
@@ -41,28 +41,28 @@ a:hover {
   text-decoration: underline;
 }
 
-div.chlorine.console .items {
+div.repl-tooling.console .items {
   margin-top: 5px;
   margin-bottom: 10px;
 }
 
-div.chlorine.error {
+div.repl-tooling.error {
   color: var(--vscode-errorForeground);
 }
 
-div.chlorine div.exception div.description {
+div.repl-tooling div.exception div.description {
   font-weight: bold;
 }
 
-div.chlorine div.exception div.additional {
+div.repl-tooling div.exception div.additional {
   margin-left: 0;
 }
 
-div.chlorine div.exception div.stack {
+div.repl-tooling div.exception div.stack {
   opacity: 0.6;
 }
 
-div.chlorine.console .cell {
+div.repl-tooling.console .cell {
   transition: all 0.1s ease;
   position: relative;
   top: 0;
@@ -70,7 +70,7 @@ div.chlorine.console .cell {
   white-space: pre-wrap;
   word-wrap: break-word;
 }
-div.chlorine.console .cell .gutter {
+div.repl-tooling.console .cell .gutter {
   width: 2em;
   height: 100%;
   float: left;
@@ -79,7 +79,7 @@ div.chlorine.console .cell .gutter {
   -webkit-user-select: none;
 }
 
-div.chlorine.console .cell .gutter .icon {
+div.repl-tooling.console .cell .gutter .icon {
   transition: all 0.1s ease;
 }
 
@@ -116,7 +116,7 @@ span.icon {
 }
 
 /* RESULTS RENDERER */
-.chlorine.result a.chevron {
+.repl-tooling.result a.chevron {
   font-family: 'Octicons Regular';
   font-weight: bold;
   font-size: 16px;
@@ -124,26 +124,62 @@ span.icon {
   width: 0px;
   height: 15px;
 }
-.chlorine.result a.chevron.closed::before {
+.repl-tooling.result a.chevron.closed::before {
   content: \"\\f078\";
 }
 
-.chlorine.result a.chevron.opened::before {
+.repl-tooling.result a.chevron.opened::before {
   content: \"\\f0a3\";
 }
 
-.chlorine.result div {
+.repl-tooling.result div {
   display: flex;
   white-space: pre;
 }
 
-.chlorine.result div.browseable,div.row {
+/* Interactive Results */
+.repl-tooling.result div.browseable,div.row {
   flex-direction: column;
 }
-.chlorine.result div .children {
+.repl-tooling.result div .children {
   flex-direction: column;
   margin-left: 1.5em;
 }
+.repl-tooling.result div div.error {
+  color: @text-color-error;
+}
+.repl-tooling.result div div.rows {
+  display: flex;
+  flex-direction: column;
+}
+.repl-tooling.result div div.cols {
+  display: flex;
+  flex-direction: row;
+}
+.repl-tooling.result div div.title {
+  font-weight: 800;
+}
+.repl-tooling.result div div.pre {
+  white-space: pre-wrap;
+}
+.repl-tooling.result div div.space {
+  opacity: 0.1;
+  margin: 0.6em;
+}
+.repl-tooling.result div select {
+}
+.repl-tooling.result div button {
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  border-width: 1px;
+  border-radius: 3px;
+}
+.repl-tooling.result div input[type=text] {
+  border: 0px @syntax-selection-color;
+  border-radius: 1px;
+  border: 0px solid @pane-item-border-color;
+}
+
 
   </style>
 </head>
@@ -154,6 +190,7 @@ span.icon {
 </html>"))))
 
 (defn post-message! [message]
+  (prn :MESSAGE message)
   (.. ^js @view -webview
       (postMessage (pr-str message))))
 

--- a/src/clover/view/console.cljs
+++ b/src/clover/view/console.cljs
@@ -62,13 +62,11 @@
   (.. js/window
       (addEventListener "message"
                         (fn [message]
-                          (prn :MESS (.-data message))
                           (let [{:keys [command obj repl]} (->> message
                                                                 .-data
                                                                 (edn/read-string {:default tagged-literal}))]
                             (case command
-                              :stdout (do 
-                                        (console/stdout obj))
+                              :stdout (console/stdout obj)
                               :stderr (console/stderr obj)
                               :result (render-result obj repl)
                               :eval-result (send-response! obj)

--- a/src/clover/view/console.cljs
+++ b/src/clover/view/console.cljs
@@ -1,64 +1,20 @@
 (ns clover.view.console
-  (:require [reagent.core :as r]
+  (:require [repl-tooling.editor-integration.renderer.console :as console]
             [repl-tooling.editor-integration.renderer :as render]
-            [repl-tooling.editor-helpers :as helpers]
-            [cljs.reader :as edn]
-            [repl-tooling.eval :as eval]
-            [clojure.core.async :as async :include-macros true]
             [repl-tooling.editor-integration.connection :as conn]
-            ["ansi_up" :default Ansi]))
-
-(defonce out-state (r/atom []))
-
-(defn- rendered-content [parsed-ratom]
-  (let [error? (-> parsed-ratom meta :error)]
-    [:div {:class ["result" "chlorine" (when error? "error")]}
-     [render/view-for-result parsed-ratom]]))
-
-(defonce ansi (new Ansi))
-(defn- cell-for [[out-type object] idx]
-  (let [kind (out-type {:stdout :output :stderr :err :result :result})
-        icon (out-type {:stdout "icon-quote" :stderr "icon-alert" :result "icon-code"})]
-    [:div.cell {:key idx}
-     [:div.gutter [:span {:class ["icon" icon]}]]
-     (if (= out-type :result)
-       [:div.content [rendered-content object]]
-       (let [html (. ansi ansi_to_html object)]
-         [:div.content [:div {:class kind :dangerouslySetInnerHTML #js {:__html html}}]]))]))
-
-(defn console-view []
-  [:div.chlorine.console.native-key-bindings {:tabindex 1}
-   [:<> (map cell-for @out-state (range))]])
-
-(defonce div (. js/document querySelector "div"))
-
-(defn- all-scrolled? []
-  (let [window-scroll-pos (+ (.. js/window -scrollY) (.. js/window -innerHeight) 1)
-        document-height (.. js/document (querySelector "body") -clientHeight)]
-    (>= window-scroll-pos document-height)))
-
-(defn- scroll-to-end! [scrolled?]
-  (when @scrolled?
-    (.scroll js/window 0 (.. js/document (querySelector "body") -clientHeight))))
-
-(defn clear []
-  (reset! out-state []))
-
-(defn- append-text [stream text]
-  (let [[old-stream old-text] (peek @out-state)]
-    (if (= old-stream stream)
-      (swap! out-state #(-> % pop (conj [stream (str old-text text)])))
-      (swap! out-state conj [stream text]))))
-
-(defn result [parsed-result repl]
-  (swap! out-state conj [:result (render/parse-result parsed-result repl (atom {}))]))
+            [repl-tooling.eval :as eval]
+            [clojure.edn :as edn]
+            [reagent.dom :as rdom]))
 
 (defn register-console! []
   (let [scrolled? (atom true)]
-    (r/render [(with-meta console-view
-                 {:component-will-update #(reset! scrolled? (all-scrolled?))
-                  :component-did-update #(scroll-to-end! scrolled?)})]
-              div)))
+    (rdom/render [(with-meta console/console-view
+                 {:get-snapshot-before-update #(reset! scrolled? (console/all-scrolled?))
+                  :component-did-update #(console/scroll-to-end! scrolled?)})]
+                 console/div)
+    (.. js/document 
+        (querySelector "div") 
+        (replaceWith console/div))))
 
 (def ^:private pending-evals (atom {}))
 (defonce ^:private post-message! (-> (js/acquireVsCodeApi) .-postMessage))
@@ -78,7 +34,6 @@
   (let [edn (edn/read-string {:default tagged-literal} string)
         txt (:as-text edn)
         key (if (:error edn) :error :result)]
-
     (-> edn
         (dissoc :parsed?)
         (assoc key txt))))
@@ -86,7 +41,7 @@
 (defn- render-result [string-result repl-flavor]
   (let [repl (->Evaluator repl-flavor)
         result (to-edn string-result)]
-    (swap! out-state conj [:result (render/parse-result result repl (atom {}))])))
+    (console/result result #(render/parse-result % repl (atom {})))))
 
 (defn- send-response! [{:keys [id result]}]
   (let [callback (get @pending-evals id)]
@@ -97,7 +52,7 @@
   (let [repl (->Evaluator :cljs)
         norm {:result (:as-text result)
               :as-text (:as-text result)}
-        results (->> @out-state
+        results (->> @console/out-state
                      (filter #(-> % first (= :result)))
                      (map second))]
     (doseq [result (conn/find-patch id results)]
@@ -107,14 +62,16 @@
   (.. js/window
       (addEventListener "message"
                         (fn [message]
+                          (prn :MESS (.-data message))
                           (let [{:keys [command obj repl]} (->> message
                                                                 .-data
                                                                 (edn/read-string {:default tagged-literal}))]
                             (case command
-                              :stdout (append-text :stdout obj)
-                              :stderr (append-text :stderr obj)
+                              :stdout (do 
+                                        (console/stdout obj))
+                              :stderr (console/stderr obj)
                               :result (render-result obj repl)
                               :eval-result (send-response! obj)
                               :patch (patch-result! obj)
-                              :clear (clear))))))
+                              :clear (console/clear))))))
   (register-console!))


### PR DESCRIPTION
- Fixed connection for other Clojure implementations like Clojerl, Joker, etc.
- Interactive results
- First support for `info` command, if "Orchard" is on classpath
- Code refactoring, fixed issues
- Loading tests on full refresh
- Fixed parsing of namespaces with metadata, and quotes (the kind you get when using clj-kondo)
- Load-file now prints the stacktrace when it fails to load
- Fixed paths on Windows, so goto var definition and clicking on stacktraces will work
- Simple fix for nREPL on slower sockets
- Alpha support for nREPL
- Fixed connection with Babashka
- Fixed issue with GOTO Var Definition when the current file's full path is too long.